### PR TITLE
Finish the current segment with an error when the response future has failed

### DIFF
--- a/kamon-akka-http/src/test/scala/kamon/akka/http/AkkaHttpClientInstrumentationSpec.scala
+++ b/kamon-akka-http/src/test/scala/kamon/akka/http/AkkaHttpClientInstrumentationSpec.scala
@@ -129,9 +129,10 @@ class AkkaHttpClientInstrumentationSpec extends BaseKamonSpec {
         val httpResponse = Await.result(responseFut, timeoutTest)
 
         httpResponse.status should be(InternalServerError)
-        testContext.finish()
+        testContext.finishWithError(new Exception("An Error Ocurred"))
 
         val traceMetricsSnapshot = takeSnapshotOf("assign-name-to-segment-with-request-level-api", "trace")
+        traceMetricsSnapshot.counter("errors").get.count should be(1)
         traceMetricsSnapshot.histogram("elapsed-time").get.numberOfMeasurements should be(1)
 
         val segmentMetricsSnapshot = takeSnapshotOf(s"request-level /$dummyPathError", "trace-segment",


### PR DESCRIPTION
This way the `errors` counter will be incremented. If this is accepted, I will add the fix to `kamon-spray` too, since it is also ignoring the failure.