### PR TITLE
Use original metric category name

### DIFF
--- a/kamon-akka-http/src/main/scala/kamon/akka/http/metrics/AkkaHttpServerMetrics.scala
+++ b/kamon-akka-http/src/main/scala/kamon/akka/http/metrics/AkkaHttpServerMetrics.scala
@@ -42,4 +42,4 @@ class AkkaHttpServerMetrics(instrumentFactory: InstrumentFactory) extends HttpSe
   def recordConnectionClosed(): Unit = connectionOpen.decrement()
 }
 
-object AkkaHttpServerMetrics extends EntityRecorderFactoryCompanion[AkkaHttpServerMetrics]("akka-http-server", new AkkaHttpServerMetrics(_))
+object AkkaHttpServerMetrics extends EntityRecorderFactoryCompanion[AkkaHttpServerMetrics]("http-server", new AkkaHttpServerMetrics(_))

--- a/kamon-akka-http/src/test/scala/kamon/akka/http/AkkaHttpServerMetricsSpec.scala
+++ b/kamon-akka-http/src/test/scala/kamon/akka/http/AkkaHttpServerMetricsSpec.scala
@@ -87,7 +87,7 @@ class AkkaHttpServerMetricsSpec extends BaseKamonSpec with Matchers {
         Http().outgoingConnection("localhost", port)
 
       // Erase metrics recorder from previous tests.
-      clean("akka-http-server", "akka-http-server")
+      clean("akka-http-server", "http-server")
 
       val okResponsesFut = for (repetition ← 1 to 10) yield {
         Source.single(HttpRequest(uri = metricsOk.withSlash))
@@ -103,7 +103,7 @@ class AkkaHttpServerMetricsSpec extends BaseKamonSpec with Matchers {
 
       Await.result(Future.sequence(okResponsesFut ++ badRequestResponsesFut), timeoutStartUpServer)
 
-      val snapshot = takeSnapshotOf("akka-http-server", "akka-http-server")
+      val snapshot = takeSnapshotOf("akka-http-server", "http-server")
       snapshot.counter("200_UnnamedTrace").get.count should be(10)
       snapshot.counter("400_UnnamedTrace").get.count should be(5)
       snapshot.counter("UnnamedTrace").get.count should be(15)


### PR DESCRIPTION
Not sure if this was an intentional decision-- but it would be helpful for us if kamon-akka-http was a drop-in replacement, metric-wise, for kamon-spray. Along with my other PR #9, this should do that.