### PR TITLE
#14 Properly handle completion state of the connection flow

### DIFF
--- a/kamon-akka-http/src/main/scala/kamon/akka/http/instrumentation/FlowWrapper.scala
+++ b/kamon-akka-http/src/main/scala/kamon/akka/http/instrumentation/FlowWrapper.scala
@@ -64,10 +64,12 @@ object FlowWrapper {
           metrics.recordRequest()
           push(requestOut, request)
         }
+        override def onUpstreamFinish(): Unit = complete(requestOut)
       })
 
       setHandler(requestOut, new OutHandler {
         override def onPull(): Unit = pull(requestIn)
+        override def onDownstreamFinish(): Unit = cancel(requestIn)
       })
 
       setHandler(responseIn, new InHandler {
@@ -86,10 +88,12 @@ object FlowWrapper {
 
           push(responseOut, response)
         }
+        override def onUpstreamFinish(): Unit = completeStage()
       })
 
       setHandler(responseOut, new OutHandler {
         override def onPull(): Unit = pull(responseIn)
+        override def onDownstreamFinish(): Unit = cancel(responseIn)
       })
 
       override def preStart(): Unit = metrics.recordConnectionOpened()


### PR DESCRIPTION
When handling chunked requests (where the connection flow may outlive
having received the last request), the current implementation would trigger
One2OneBidiFlow$OutputTruncationException in #14.

This commit fixes this by adding the relevant on[...]Finish methods.