### PR TITLE
Add monitoring of pool connection and queue state

### DIFF
--- a/kamon-akka-http/src/main/resources/META-INF/aop.xml
+++ b/kamon-akka-http/src/main/resources/META-INF/aop.xml
@@ -7,6 +7,12 @@
 
     <!-- Akka Http Client -->
     <aspect name="kamon.akka.http.instrumentation.ClientRequestInstrumentation"/>
+    
+    <!-- Akka Http Client, pool connection state -->
+    <aspect name="kamon.akka.http.instrumentation.PoolConductorInstrumentation"/>
+
+    <!-- Akka Http Client, pool queue state -->
+    <aspect name="akka.http.impl.engine.client.PoolInterfaceActorInstrumentation"/>
   </aspects>
 
   <weaver options="-warn:none">

--- a/kamon-akka-http/src/main/scala/akka/http/impl/engine/client/PoolInterfaceActorInstrumentation.scala
+++ b/kamon-akka-http/src/main/scala/akka/http/impl/engine/client/PoolInterfaceActorInstrumentation.scala
@@ -1,0 +1,43 @@
+// Declared inside the akka package to rely a bit more on the compiler, and a bit less on reflection-only.
+package akka.http.impl.engine.client
+
+import org.aspectj.lang.annotation.After
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.annotation.Pointcut
+import akka.http.impl.settings.HostConnectionPoolSetup
+import akka.stream.impl.Buffer
+import kamon.Kamon
+
+@Aspect
+class PoolInterfaceActorInstrumentation {
+  val inputBufferField = classOf[PoolInterfaceActor].getDeclaredField("akka$http$impl$engine$client$PoolInterfaceActor$$inputBuffer")
+  val hcpsField = classOf[PoolInterfaceActor].getDeclaredField("akka$http$impl$engine$client$PoolInterfaceActor$$hcps")
+  
+  @Pointcut("execution(akka.http.impl.engine.client.PoolInterfaceActor.new(..)) && this(poolInterfaceActor)")
+  def create(poolInterfaceActor: AnyRef): Unit = {}
+  
+  @After("create(actor)")
+  def afterCreate(poolInterfaceActor: AnyRef): Unit = {
+    inputBufferField.setAccessible(true)
+    val buffer = inputBufferField.get(poolInterfaceActor).asInstanceOf[Buffer[_]]
+    hcpsField.setAccessible(true)
+    val hcps = hcpsField.get(poolInterfaceActor).asInstanceOf[HostConnectionPoolSetup]
+    
+    val tags = Map("target_host" -> hcps.host, "target_port" -> hcps.port.toString)
+    Kamon.metrics.gauge("http-client.pool.queue.used", tags) { () => buffer.used.toLong }
+    Kamon.metrics.gauge("http-client.pool.queue.capacity", tags) { () => buffer.capacity.toLong }
+  }
+  
+  @Pointcut("execution(* akka.http.impl.engine.client.PoolInterfaceActor.afterStop(..)) && this(actor)")
+  def stop(actor: PoolInterfaceActor): Unit = {}
+  
+  @After("stop(actor)")
+  def afterStop(actor: PoolInterfaceActor): Unit = {
+    hcpsField.setAccessible(true)
+    val hcps = hcpsField.get(actor).asInstanceOf[HostConnectionPoolSetup]
+
+    val tags = Map("target_host" -> hcps.host, "target_port" -> hcps.port.toString)
+    Kamon.metrics.removeGauge("http-client.pool.queue.used", tags)
+    Kamon.metrics.removeGauge("http-client.pool.queue.capacity", tags)
+  }
+}

--- a/kamon-akka-http/src/main/scala/kamon/akka/http/instrumentation/PoolConductorInstrumentation.scala
+++ b/kamon-akka-http/src/main/scala/kamon/akka/http/instrumentation/PoolConductorInstrumentation.scala
@@ -1,0 +1,64 @@
+package kamon.akka.http.instrumentation
+
+import org.aspectj.lang.annotation.After
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.annotation.Pointcut
+import akka.event.BusLogging
+import kamon.Kamon
+import kamon.metric.instrument.Gauge.functionZeroAsCurrentValueCollector
+
+@Aspect
+class PoolConductorInstrumentation {
+  val slotStatesField = Class.forName("akka.http.impl.engine.client.PoolConductor$SlotSelector$$anon$1").getDeclaredField("slotStates")
+  val slotSelectorField = Class.forName("akka.http.impl.engine.client.PoolConductor$SlotSelector$$anon$1").getDeclaredField("$outer")
+  val logField = Class.forName("akka.http.impl.engine.client.PoolConductor$SlotSelector").getDeclaredField("log")
+  
+  @Pointcut("execution(akka.http.impl.engine.client.PoolConductor$SlotSelector$$anon$1.new(..)) && this(logic)")
+  def newGraphStageLogic(logic: AnyRef): Unit = {}
+  
+  private val HOST = raw"//(.+):".r
+  private val PORT = raw":([0-9]+)".r
+
+  private def getTags(graphStageLogic: AnyRef): Map[String,String] = {
+    slotSelectorField.setAccessible(true)
+    val slotSelector = slotSelectorField.get(graphStageLogic)
+    
+    logField.setAccessible(true)
+    val log = logField.get(slotSelector).asInstanceOf[BusLogging]
+    val host = HOST.findFirstMatchIn(log.logSource).map(_.group(1)).getOrElse("unknown")
+    val port = PORT.findAllMatchIn(log.logSource).toVector.lastOption.map(_.group(1)).getOrElse("80")
+    
+    Map("target_host" -> host, "target_port" -> port)
+  }
+  
+  private val states: Map[String,Class[_]] = Map(
+    "idle" -> Class.forName("akka.http.impl.engine.client.PoolConductor$Idle$"),
+    "unconnected" -> Class.forName("akka.http.impl.engine.client.PoolConductor$Unconnected$"),
+    "loaded" -> Class.forName("akka.http.impl.engine.client.PoolConductor$Loaded"),
+    "busy" -> Class.forName("akka.http.impl.engine.client.PoolConductor$Busy"))
+  
+  @After("newGraphStageLogic(logic)")
+  def afterNewGraphStageLogic(logic: AnyRef): Unit = {
+    slotStatesField.setAccessible(true)
+    val slotStates = slotStatesField.get(logic).asInstanceOf[Array[_]]
+    
+    val tags = getTags(logic)    
+    for ((name, stateClass) <- states) {
+      // note: don't use "host" as a tag, since for Datadog, it will cause dogstatsd to swallow ALL _other_ default tags. 
+      Kamon.metrics.gauge(s"http-client.pool.connections.${name}", tags) { 
+        () => slotStates.count(s => s.getClass() eq stateClass).toLong
+      }
+    }
+  }
+  
+  @Pointcut("execution(akka.http.impl.engine.client.PoolConductor$SlotSelector$$anon$1.postStop(..)) && this(logic)")
+  def postStopGraphStageLogic(logic: AnyRef): Unit = {}
+  
+  @After("postStopGraphStageLogic(logic)")
+  def afterPostStopGraphStageLogic(logic: AnyRef): Unit = {
+    val tags = getTags(logic)    
+    for ((name, _) <- states) {
+      Kamon.metrics.removeGauge(s"http-client.pool.connections.${name}", tags)
+    }
+  }
+}


### PR DESCRIPTION
Unfortunately, the only current way to do that is to reflect deeply into
the internals of akka's pool implementation.

Let's hope that https://github.com/akka/akka-http/issues/1025 will yield
a more proper API for this.