### PR TITLE
Finish the span only when the entity is completely drained

### DIFF
--- a/kamon-akka-http/src/main/resources/reference.conf
+++ b/kamon-akka-http/src/main/resources/reference.conf
@@ -17,6 +17,8 @@ kamon.akka-http {
   # Add http status codes as metric tags. The default value is false
   add-http-status-code-as-metric-tag = false
 
+  not-found-operation-name = "unhandled"
+
   modules {
     kamon-akka-http {
       requires-aspectj = yes

--- a/kamon-akka-http/src/test/scala/kamon/akka/http/AkkaHttpClientTracingSpec.scala
+++ b/kamon-akka-http/src/test/scala/kamon/akka/http/AkkaHttpClientTracingSpec.scala
@@ -51,7 +51,7 @@ class AkkaHttpClientTracingSpec extends WordSpecLike with Matchers with BeforeAn
   "the Akka HTTP client instrumentation" should {
     "create a client Span when using the request level API - Http().singleRequest(...)" in {
       val target = s"http://$interface:$port/$dummyPathOk"
-      Http().singleRequest(HttpRequest(uri = target))
+      Http().singleRequest(HttpRequest(uri = target)).map(_.discardEntityBytes())
 
       eventually(timeout(10 seconds)) {
         val span = reporter.nextSpan().value
@@ -68,7 +68,7 @@ class AkkaHttpClientTracingSpec extends WordSpecLike with Matchers with BeforeAn
     "pick up customizations from the SpanCustomizer in context" in {
       val target = s"http://$interface:$port/$dummyPathOk"
       Kamon.withContextKey(SpanCustomizer.ContextKey, SpanCustomizer.forOperationName("get-dummy-path")) {
-        Http().singleRequest(HttpRequest(uri = target))
+        Http().singleRequest(HttpRequest(uri = target)).map(_.discardEntityBytes())
       }
 
       eventually(timeout(10 seconds)) {
@@ -107,7 +107,7 @@ class AkkaHttpClientTracingSpec extends WordSpecLike with Matchers with BeforeAn
 
     "mark Spans as errors if the client request failed" in {
       val target = s"http://$interface:$port/$dummyPathError"
-      Http().singleRequest(HttpRequest(uri = target))
+      Http().singleRequest(HttpRequest(uri = target)).map(_.discardEntityBytes())
 
       eventually(timeout(10 seconds)) {
         val span = reporter.nextSpan().value

--- a/kamon-akka-http/src/test/scala/kamon/akka/http/AkkaHttpServerMetricsSpec.scala
+++ b/kamon-akka-http/src/test/scala/kamon/akka/http/AkkaHttpServerMetricsSpec.scala
@@ -71,6 +71,10 @@ class AkkaHttpServerMetricsSpec extends WordSpecLike with Matchers with BeforeAn
     val connectionSettings = ClientConnectionSettings(system).withIdleTimeout(1 second)
     Source.single(request)
       .via(Http().outgoingConnection(interface, port, settings = connectionSettings))
+      .map{r =>
+        r.discardEntityBytes()
+        r
+      }
       .runWith(Sink.head)
   }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.17


### PR DESCRIPTION
Also, make the 404 operation re-name configurable