### PR TITLE
Header names are case insensitive by spec, so we should respect that

### DIFF
--- a/kamon-akka-http/src/main/scala/kamon/akka/http/instrumentation/ServerFlowWrapper.scala
+++ b/kamon-akka-http/src/main/scala/kamon/akka/http/instrumentation/ServerFlowWrapper.scala
@@ -16,6 +16,8 @@
 
 package kamon.akka.http.instrumentation
 
+import scala.collection.immutable.TreeMap
+
 import akka.NotUsed
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
@@ -123,7 +125,9 @@ object ServerFlowWrapper {
   }
 
   private def extractContext(request: HttpRequest) = Kamon.contextCodec().HttpHeaders.decode(new TextMap {
-    private val headersKeyValueMap = request.headers.map(h => h.name -> h.value()).toMap
+    private val headersKeyValueMap =
+      new TreeMap[String, String]()(Ordering.comparatorToOrdering(String.CASE_INSENSITIVE_ORDER)) ++
+        request.headers.map(h => h.name -> h.value())
     override def values: Iterator[(String, String)] = headersKeyValueMap.iterator
     override def get(key: String): Option[String] = headersKeyValueMap.get(key)
     override def put(key: String, value: String): Unit = {}


### PR DESCRIPTION
I ran into this when using kamon-jaeger, and receiving B3 span headers which differed in how they were capitalised from the strings in code (e.g. kamon core has `"X-B3-SpanId"`, whereas some clients were sending `"x-b3-spanid"`). This appears to fix my use case, and should apply in general given HTTP RFC 7230