### PR TITLE
WIP Add path directives that shadow akka's directives

### DIFF
--- a/kamon-akka-http/src/main/java/kamon/akka/http/CustomOperationNameGenerator.java
+++ b/kamon-akka-http/src/main/java/kamon/akka/http/CustomOperationNameGenerator.java
@@ -1,0 +1,59 @@
+package kamon.akka.http;
+
+import akka.http.javadsl.model.headers.Host;
+import akka.http.scaladsl.model.HttpRequest;
+import kamon.Kamon;
+import kamon.akka.http.AkkaHttp.OperationNameGenerator;
+import kamon.trace.Span;
+
+/**
+ * Generates a fixed operation name for server traces, but allows that name to be replaced with
+ * prefixable/postfixable names instead. This goes togeter with the path*() methods in {@link Directives}.
+ */
+public class CustomOperationNameGenerator implements OperationNameGenerator {
+    private static final String DEFAULT = "unknown";
+
+    @Override
+    public String clientOperationName(HttpRequest request) {
+        String host = request.uri().authority().host().address();
+        if (host.isEmpty()) {
+            host = request.getHeader(Host.class).map(h -> h.host().toString()).orElse("unknown-host");
+        }
+        int port = request.uri().authority().port();
+        if (port == 0) {
+            port = request.getHeader(Host.class).map(h -> h.port()).orElse(0);
+        }
+        if (port == 0) {
+            if (request.uri().scheme().equals("http")) {
+                port = 80;
+            } else if (request.uri().scheme().equals("https")) {
+                port = 443;
+            }
+        }
+        return host + ":" + port;
+    }
+
+    @Override
+    public String serverOperationName(HttpRequest request) {
+        // We start out with "unknown", replacing this whenever append() is called.
+        return DEFAULT;
+    }
+
+    /**
+     * Appends the given string to the current operation name.
+     */
+    public static void append(String separator, String postfix) {
+        Span span = Kamon.currentSpan();                                             // NOTEST (we don't want kamon active in unit tests)
+        String n = span.operationName();                                             // NOTEST
+        span.setOperationName(n.equals(DEFAULT) ? postfix : n + separator + postfix);// NOTEST
+    }
+
+    /**
+     * Prepends the given string to the current operation name.
+     */
+    public static void prepend(String prefix, String separator) {
+        Span span = Kamon.currentSpan();                                              // NOTEST
+        String n = span.operationName();                                              // NOTEST
+        span.setOperationName(n.equals(DEFAULT) ? prefix : prefix + separator + n);   // NOTEST
+    }
+}

--- a/kamon-akka-http/src/main/java/kamon/akka/http/javadsl/Directives.java
+++ b/kamon-akka-http/src/main/java/kamon/akka/http/javadsl/Directives.java
@@ -1,0 +1,59 @@
+package kamon.akka.http.javadsl;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import akka.http.javadsl.server.PathMatcher1;
+import akka.http.javadsl.server.Route;
+import akka.http.javadsl.unmarshalling.Unmarshaller;
+
+public class Directives {
+    /** Same as akka's pathPrefix directive, but adds the path to the current Kamon trace operation name. */
+    public static Route pathPrefix(String prefix, Supplier<Route> inner) {
+        return akka.http.javadsl.server.Directives.pathPrefix(prefix, () ->
+            appendPathToOperationName(prefix, inner)
+        );
+    }
+
+    /** Same as akka's pathPrefix directive, but adds the path to the current Kamon trace operation name. */
+    public static <T> Route pathPrefix(Unmarshaller<String,T> un, Function<T,Route> inner) {
+        return akka.http.javadsl.server.Directives.pathPrefix(un, t ->
+            appendPathToOperationName("{}", () -> inner.apply(t))
+        );
+    }
+
+    /** Same as akka's pathPrefix directive, but adds the path to the current Kamon trace operation name. */
+    public static Route pathPrefix(Function<String,Route> inner) {
+        return akka.http.javadsl.server.Directives.pathPrefix(segment ->
+            appendPathToOperationName("{}", () -> inner.apply(segment))
+        );
+    }
+
+    /** Same as akka's path directive, but adds the path to the current Kamon trace operation name. */
+    public static Route path(String prefix, Supplier<Route> inner) {
+        return akka.http.javadsl.server.Directives.path(prefix, () ->
+            appendPathToOperationName(prefix, inner)
+        );
+    }
+
+    /** Same as akka's path directive, but adds the path to the current Kamon trace operation name. */
+    public static <T> Route path(PathMatcher1<T> m, Function<T,Route> inner) {
+        return akka.http.javadsl.server.Directives.path(m, t ->
+            appendPathToOperationName("{}", () -> inner.apply(t))
+        );
+    }
+
+    /** Same as akka's path directive, but adds the path to the current Kamon trace operation name. */
+    public static Route path(Function<String,Route> inner) {
+        return akka.http.javadsl.server.Directives.path(segment ->
+            appendPathToOperationName("{}", () -> inner.apply(segment))
+        );
+    }
+
+    private static Route appendPathToOperationName(String postfix, Supplier<Route> inner) {
+        return akka.http.javadsl.server.Directives.mapRequest(req -> {
+            CustomOperationNameGenerator.append("/", postfix);
+            return req;
+        }, inner);
+    }
+}


### PR DESCRIPTION
Our custom directives can be imported instead of akka's. Users can still
say `pathPrefix` etc., but now kamon's operation name is automatically
extended whenever sub-paths are entered that way.

Currently, a custom `OperationNameGenerator` is needed, since otherwise kamon's default will step in and overwrite our work :-)