### PR TITLE
Exclude path extractions from operationName

### DIFF
--- a/kamon-akka-http-playground/src/main/scala/playground/WebServer.scala
+++ b/kamon-akka-http-playground/src/main/scala/playground/WebServer.scala
@@ -38,7 +38,6 @@ object WebServer extends App {
   implicit val materializer = ActorMaterializer()
 
   val logger = Logging(system, getClass)
-
   val routes = { // logRequestResult("akka-http-with-kamon") {
     get {
       path("ok") {

--- a/kamon-akka-http/src/main/resources/META-INF/aop.xml
+++ b/kamon-akka-http/src/main/resources/META-INF/aop.xml
@@ -4,6 +4,7 @@
   <aspects>
     <!-- Akka Http Server -->
     <aspect name="kamon.akka.http.instrumentation.ServerRequestInstrumentation"/>
+    <aspect name="kamon.akka.http.instrumentation.MatchingContextIntoRequestContext"/>
 
     <!-- Akka Http Client -->
     <aspect name="akka.http.impl.engine.client.ClientRequestInstrumentation"/>

--- a/kamon-akka-http/src/main/scala/kamon/akka/http/instrumentation/ServerRequestInstrumentation.scala
+++ b/kamon-akka-http/src/main/scala/kamon/akka/http/instrumentation/ServerRequestInstrumentation.scala
@@ -20,14 +20,19 @@ import akka.NotUsed
 import akka.event.LoggingAdapter
 import akka.http.scaladsl.ConnectionContext
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import akka.http.scaladsl.server.PathMatcher.{Matched, Unmatched}
+import akka.http.scaladsl.server.directives.RouteDirectives.reject
+import akka.http.scaladsl.server.directives.{BasicDirectives, PathDirectives}
+import akka.http.scaladsl.server.{PathMatcher, RequestContext}
 import akka.http.scaladsl.settings.ServerSettings
 import akka.stream.Materializer
 import akka.stream.scaladsl.Flow
 import org.aspectj.lang.ProceedingJoinPoint
-import org.aspectj.lang.annotation.{Around, Aspect}
+import org.aspectj.lang.annotation.{Around, Aspect, DeclareMixin}
+import kamon.Kamon
 
 @Aspect
-class ServerRequestInstrumentation {
+class ServerRequestInstrumentation extends BasicDirectives with PathDirectives  {
 
   @Around("execution(* akka.http.scaladsl.HttpExt.bindAndHandle(..)) && args(handler, interface, port, connectionContext, settings, log, materializer)")
   def onBindAndHandle(pjp: ProceedingJoinPoint, handler: Flow[HttpRequest, HttpResponse, Any], interface: String,
@@ -36,4 +41,85 @@ class ServerRequestInstrumentation {
     val originalFLow = handler.asInstanceOf[Flow[HttpRequest, HttpResponse, NotUsed]]
     pjp.proceed(Array(ServerFlowWrapper(originalFLow, interface, port), interface, Int.box(port), connectionContext, settings, log, materializer))
   }
+
+  @Around("execution(* akka.http.scaladsl.server.directives.PathDirectives.rawPathPrefix(..)) && args(matcher)")
+  def aroundExtract[T](pjp: ProceedingJoinPoint, matcher: PathMatcher[T]): AnyRef = {
+    implicit val LIsTuple = matcher.ev
+    extract(ctx => {
+      val fullPath = ctx.unmatchedPath.toString()
+      val matching = matcher(ctx.unmatchedPath)
+      matching match {
+        case m: Matched[_] =>
+          ctx.asInstanceOf[MatchingContext].prepend(PathMatchContext(fullPath, m))
+        case _ => //TODO mark as rejected?
+      }
+      matching
+    }).flatMap {
+      case Matched(rest, values) ⇒ tprovide(values) & mapRequestContext(_ withUnmatchedPath rest)
+      case Unmatched             ⇒ reject
+    }
+  }
+
+
+  @Around("execution(* akka.http.scaladsl.server.RequestContextImpl.complete(..)) && this(ctx)")
+  def aroundCtxComplete(pjp: ProceedingJoinPoint, ctx: RequestContext): AnyRef = {
+    val allMatches = ctx.asInstanceOf[MatchingContext].matchingContext.reverse.map(singleMatch)
+    val operationName = allMatches.mkString("")
+    Kamon.currentSpan().setOperationName(operationName)
+    pjp.proceed()
+  }
+
+
+  private def singleMatch(matching: PathMatchContext): String = {
+    val rest = matching.matched.pathRest.toString()
+    val consumedCount = matching.fullPath.length - rest.length
+    val consumedSegment = matching.fullPath.substring(0, consumedCount)
+
+    matching.matched.extractions match {
+      case () => //string segment matched
+        consumedSegment
+      case tuple: Product =>
+        val values = tuple.productIterator.toList map {
+          case Some(x)    => List(x.toString)
+          case None       => Nil
+          case long: Long => List(long.toString, long.toHexString)
+          case int: Int   => List(int.toString, int.toHexString)
+          case a: Any     => List(a.toString)
+        }
+        values.flatten.fold(consumedSegment)((full, value) => full.replaceFirst(s"(?i)$value", "{}"))
+    }
+  }
+
+
+  @Around("execution(* akka.http.scaladsl.server.RequestContextImpl.copy(..)) && this(ctx)")
+  def aroundCtxCopy(pjp: ProceedingJoinPoint, ctx: RequestContext): AnyRef = {
+    val copy = pjp.proceed()
+    copy.asInstanceOf[MatchingContext].set(ctx.asInstanceOf[MatchingContext].matchingContext)
+    copy
+  }
+
+
+}
+
+case class PathMatchContext(fullPath: String, matched: Matched[_])
+trait MatchingContext {
+  def matchingContext: Seq[PathMatchContext]
+  def set(ctx: Seq[PathMatchContext])
+  def prepend(matched: PathMatchContext)
+}
+
+object MatchingContext {
+  def apply(): MatchingContext = new MatchingContext {
+    var matchingContext: Seq[PathMatchContext] = Seq.empty
+    override def prepend(matched: PathMatchContext): Unit = matchingContext = matched +: matchingContext
+    override def set(ctx: Seq[PathMatchContext]): Unit = matchingContext = ctx
+  }
+}
+
+@Aspect
+class MatchingContextIntoRequestContext {
+
+  @DeclareMixin("akka.http.scaladsl.server.RequestContextImpl")
+  def matchedSegmentsToContext: MatchingContext = MatchingContext()
+
 }

--- a/kamon-akka-http/src/test/scala/kamon/akka/http/AkkaHttpServerTracingSpec.scala
+++ b/kamon-akka-http/src/test/scala/kamon/akka/http/AkkaHttpServerTracingSpec.scala
@@ -77,18 +77,16 @@ class AkkaHttpServerTracingSpec extends WordSpecLike
            span.operationName shouldBe expected
          }
        }
-      "including concatenated matchers" in {
-        val path = s"extraction/concat/fixed${UUID.randomUUID().toString}CaFe"
-        val expected = "/extraction/concat/fixed{}{}"
+      "including ambiguous nested directives" in {
+        val path = s"v3/user/3/post/3"
+        val expected = "/v3/user/{}/post/{}"
         val target = s"http://$interface:$port/$path"
         Http().singleRequest(HttpRequest(uri = target)).map(_.discardEntityBytes())
-
         eventually(timeout(10 seconds)) {
           val span = reporter.nextSpan().value
           span.operationName shouldBe expected
         }
       }
-
     }
 
     //TODO decide what to do with operationName directive, currently whatever it sets gets overriden by instrumentation when route is completed

--- a/kamon-akka-http/src/test/scala/kamon/testkit/TestNameGenerator.scala
+++ b/kamon-akka-http/src/test/scala/kamon/testkit/TestNameGenerator.scala
@@ -22,7 +22,6 @@ import kamon.akka.http.AkkaHttp.OperationNameGenerator
 class TestNameGenerator extends OperationNameGenerator {
   def serverOperationName(request: HttpRequest): String = {
     val path = request.uri.path.toString()
-
     // turns "/dummy-path" into "dummy"
     path.substring(1).split("-")(0)
   }

--- a/kamon-akka-http/src/test/scala/kamon/testkit/TestWebServer.scala
+++ b/kamon-akka-http/src/test/scala/kamon/testkit/TestWebServer.scala
@@ -48,6 +48,24 @@ trait TestWebServer extends TracingDirectives {
 
     val routes = logRequest("routing-request") {
       get {
+        pathPrefix("extraction") {
+          (post | get) {
+            pathPrefix("nested") {
+              pathPrefix(IntNumber / "fixed") { num =>
+                pathPrefix("anchor" / IntNumber.? / JavaUUID / "fixed") { (number, uuid) =>
+                  pathPrefix(LongNumber / HexIntNumber) { (longNum, hex) =>
+                    complete("OK")
+                  }
+                }
+              }
+            } ~
+            pathPrefix("concat") {
+              path("fixed" ~ JavaUUID ~ HexIntNumber) { (uuid, num) =>
+                complete("OK")
+              }
+            }
+          }
+        } ~
         path(rootOk) {
           complete(OK)
         } ~

--- a/kamon-akka-http/src/test/scala/kamon/testkit/TestWebServer.scala
+++ b/kamon-akka-http/src/test/scala/kamon/testkit/TestWebServer.scala
@@ -48,6 +48,9 @@ trait TestWebServer extends TracingDirectives {
 
     val routes = logRequest("routing-request") {
       get {
+        path("v3" / "user" / IntNumber / "post" / IntNumber) { (_, _) =>
+          complete("OK")
+        } ~
         pathPrefix("extraction") {
           (post | get) {
             pathPrefix("nested") {


### PR DESCRIPTION
Instruments `rawPathPrefix` directive to track all matched segments using `RequestContext` mixin.
Once context is completed, all matched segments are replaced with `{}` in the request path used as span operationName.

Open issue here is what to do with Kamon's `operationName` directive which gets overriden downstream when context is completed. 

Handles both nested extractors and cases like `pathPrefix(IntNumber / "fixedsegments" ...   / JavaUUID )` 