### PR TITLE
WIP: Async handler instrumentation

### DIFF
--- a/kamon-akka-http/src/test/scala/kamon/akka/http/AkkaHttpServerMetricsSpec.scala
+++ b/kamon-akka-http/src/test/scala/kamon/akka/http/AkkaHttpServerMetricsSpec.scala
@@ -60,7 +60,7 @@ abstract class AkkaHttpServerMetricsSpec extends WordSpecLike with Matchers with
         ActiveRequests.refine(httpServerMetricsTags).distribution().max shouldBe(8)
       }
 
-      eventually(timeout(10 seconds)) {
+      eventually(timeout(20 seconds)) {
         OpenConnections.refine(httpServerMetricsTags).distribution().max shouldBe(0)
         ActiveRequests.refine(httpServerMetricsTags).distribution().max shouldBe(0)
       }


### PR DESCRIPTION
This is a very naive implementation of instrumentation for the `bindAndHandleAsync` method, which is the only way to get HTTP/2 with Akka Http right now.

It seems to be working but one of the tests fails, in particular the one that expects the number of connections to be zero... which makes sense since I could not find a way to complete the flow... Any ideas?

Fixes #48 