### PR TITLE
Replace path variables with special characters in operation name

### DIFF
--- a/kamon-akka-http/src/main/scala/kamon/akka/http/instrumentation/ServerRequestInstrumentation.scala
+++ b/kamon-akka-http/src/main/scala/kamon/akka/http/instrumentation/ServerRequestInstrumentation.scala
@@ -16,6 +16,8 @@
 
 package kamon.akka.http.instrumentation
 
+import java.util.regex.Pattern
+
 import akka.NotUsed
 import akka.event.LoggingAdapter
 import akka.http.scaladsl.ConnectionContext
@@ -87,7 +89,7 @@ class ServerRequestInstrumentation extends BasicDirectives with PathDirectives  
           case a: Any     => List(a.toString)
         }
         values.flatten.fold(consumedSegment) { (full, value) =>
-          val r = s"(?i)(^|/)" + value + "($|/)"
+          val r = s"(?i)(^|/)" + Pattern.quote(value) + "($|/)"
           full.replaceFirst(r, "$1{}$2")
         }
     }

--- a/kamon-akka-http/src/test/scala/kamon/testkit/TestWebServer.scala
+++ b/kamon-akka-http/src/test/scala/kamon/testkit/TestWebServer.scala
@@ -66,6 +66,11 @@ trait TestWebServer extends TracingDirectives {
               path("fixed" ~ JavaUUID ~ HexIntNumber) { (uuid, num) =>
                 complete("OK")
               }
+            } ~
+            pathPrefix("special-chars") {
+              path("fixed" / Segment) { _ =>
+                complete("OK")
+              }
             }
           }
         } ~


### PR DESCRIPTION
If a path variable has some special characters for regular expressions, it's not replaced in operation name. A simple fix is to escape the variable parameter with `Pattern.quote`.
A new test case was added as an example. 