### PR TITLE
use a Context entry to keep the last automatic operation name edit, fixes #58

### DIFF
--- a/kamon-akka-http/src/main/scala-2.11/kamon/instrumentation/akka/http/AkkaHttpServerInstrumentation.scala
+++ b/kamon-akka-http/src/main/scala-2.11/kamon/instrumentation/akka/http/AkkaHttpServerInstrumentation.scala
@@ -23,6 +23,8 @@ import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 import java.util.regex.Pattern
 
+import kamon.context.Context
+
 
 class AkkaHttpServerInstrumentation extends InstrumentationBuilder {
 
@@ -159,22 +161,25 @@ object ResolveOperationNameOnRouteInterceptor {
     }
 
   private def resolveOperationName(requestContext: RequestContext): RequestContext = {
-    val defaultOperationName = ServerFlowWrapper.defaultOperationName(requestContext.request.uri.authority.port)
 
-    // We will only change the operation name if no change was applied to it. At this point, the only way in which it
-    // might have changed is if the user changed it with the operationName directive or just accessing the Span and
-    // changing it there, so we wouldn't want to overwrite that.
-    //
-    if(Kamon.currentSpan().operationName() == defaultOperationName) {
-      val allMatches = requestContext.asInstanceOf[HasMatchingContext].matchingContext.reverse.map(singleMatch)
-      val operationName = allMatches.mkString("")
+    // We will only change the operation name if the last edit made to it was an automatic one. At this point, the only
+    // way in which the operation name might have changed is if the user changed it with the operationName directive or
+    // by accessing the Span and changing it directly there, so we wouldn't want to overwrite that.
 
-      if(operationName.nonEmpty) {
-        Kamon.currentSpan()
-          .name(operationName)
-          .takeSamplingDecision()
+    Kamon.currentContext().get(LastAutomaticOperationNameEdit.Key).foreach(lastEdit => {
+      if(Kamon.currentSpan().operationName() == lastEdit.operationName) {
+        val allMatches = requestContext.asInstanceOf[HasMatchingContext].matchingContext.reverse.map(singleMatch)
+        val operationName = allMatches.mkString("")
+
+        if(operationName.nonEmpty) {
+          Kamon.currentSpan()
+            .name(operationName)
+            .takeSamplingDecision()
+
+          lastEdit.operationName = operationName
+        }
       }
-    }
+    })
 
     requestContext
   }
@@ -201,6 +206,16 @@ object ResolveOperationNameOnRouteInterceptor {
         }
     }
   }
+}
+
+
+class LastAutomaticOperationNameEdit(@volatile var operationName: String)
+
+object LastAutomaticOperationNameEdit {
+  val Key = Context.key[Option[LastAutomaticOperationNameEdit]]("laone", None)
+
+  def apply(operationName: String): LastAutomaticOperationNameEdit =
+    new LastAutomaticOperationNameEdit(operationName)
 }
 
 object RequestContextCopyInterceptor {

--- a/kamon-akka-http/src/main/scala-2.13/kamon/instrumentation/akka/http/AkkaHttpServerInstrumentation.scala
+++ b/kamon-akka-http/src/main/scala-2.13/kamon/instrumentation/akka/http/AkkaHttpServerInstrumentation.scala
@@ -18,10 +18,12 @@ import kanela.agent.api.instrumentation.InstrumentationBuilder
 import kanela.agent.api.instrumentation.mixin.Initializer
 import kanela.agent.libs.net.bytebuddy.implementation.bind.annotation._
 
-import scala.concurrent.{ExecutionContext, Future, Promise, Batchable}
+import scala.concurrent.{Batchable, ExecutionContext, Future, Promise}
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 import java.util.regex.Pattern
+
+import kamon.context.Context
 
 
 class AkkaHttpServerInstrumentation extends InstrumentationBuilder {
@@ -157,22 +159,25 @@ object ResolveOperationNameOnRouteInterceptor {
     }
 
   private def resolveOperationName(requestContext: RequestContext): RequestContext = {
-    val defaultOperationName = ServerFlowWrapper.defaultOperationName(requestContext.request.uri.authority.port)
 
-    // We will only change the operation name if no change was applied to it. At this point, the only way in which it
-    // might have changed is if the user changed it with the operationName directive or just accessing the Span and
-    // changing it there, so we wouldn't want to overwrite that.
-    //
-    if(Kamon.currentSpan().operationName() == defaultOperationName) {
-      val allMatches = requestContext.asInstanceOf[HasMatchingContext].matchingContext.reverse.map(singleMatch)
-      val operationName = allMatches.mkString("")
+    // We will only change the operation name if the last edit made to it was an automatic one. At this point, the only
+    // way in which the operation name might have changed is if the user changed it with the operationName directive or
+    // by accessing the Span and changing it directly there, so we wouldn't want to overwrite that.
 
-      if(operationName.nonEmpty) {
-        Kamon.currentSpan()
-          .name(operationName)
-          .takeSamplingDecision()
+    Kamon.currentContext().get(LastAutomaticOperationNameEdit.Key).foreach(lastEdit => {
+      if(Kamon.currentSpan().operationName() == lastEdit.operationName) {
+        val allMatches = requestContext.asInstanceOf[HasMatchingContext].matchingContext.reverse.map(singleMatch)
+        val operationName = allMatches.mkString("")
+
+        if(operationName.nonEmpty) {
+          Kamon.currentSpan()
+            .name(operationName)
+            .takeSamplingDecision()
+
+          lastEdit.operationName = operationName
+        }
       }
-    }
+    })
 
     requestContext
   }
@@ -199,6 +204,15 @@ object ResolveOperationNameOnRouteInterceptor {
         }
     }
   }
+}
+
+class LastAutomaticOperationNameEdit(@volatile var operationName: String)
+
+object LastAutomaticOperationNameEdit {
+  val Key = Context.key[Option[LastAutomaticOperationNameEdit]]("laone", None)
+
+  def apply(operationName: String): LastAutomaticOperationNameEdit =
+    new LastAutomaticOperationNameEdit(operationName)
 }
 
 object RequestContextCopyInterceptor {

--- a/kamon-akka-http/src/main/scala/kamon/instrumentation/akka/http/ServerFlowWrapper.scala
+++ b/kamon-akka-http/src/main/scala/kamon/instrumentation/akka/http/ServerFlowWrapper.scala
@@ -69,7 +69,10 @@ object ServerFlowWrapper {
 
           // The only reason why it's safe to leave the Thread dirty is because the Actor
           // instrumentation will cleanup afterwards.
-          Kamon.storeContext(requestHandler.context)
+          Kamon.storeContext(requestHandler.context.withEntry(
+            LastAutomaticOperationNameEdit.Key, Option(LastAutomaticOperationNameEdit(requestHandler.span.operationName()))
+          ))
+
           push(requestOut, request)
         }
 

--- a/kamon-akka-http/src/test/scala/kamon/akka/http/AkkaHttpServerTracingSpec.scala
+++ b/kamon-akka-http/src/test/scala/kamon/akka/http/AkkaHttpServerTracingSpec.scala
@@ -90,7 +90,7 @@ class AkkaHttpServerTracingSpec extends WordSpecLike with Matchers with ScalaFut
 
       "take a sampling decision when the routing tree hits an onComplete directive" in {
         val path = "extraction/on-complete/42/more-path"
-        val expected = "/extraction/on-complete/{}"
+        val expected = "/extraction/on-complete/{}/more-path"
         val target = s"http://$interface:$port/$path"
         Http().singleRequest(HttpRequest(uri = target)).map(_.discardEntityBytes())
 
@@ -102,7 +102,7 @@ class AkkaHttpServerTracingSpec extends WordSpecLike with Matchers with ScalaFut
 
       "take a sampling decision when the routing tree hits an onSuccess directive" in {
         val path = "extraction/on-success/42/after"
-        val expected = "/extraction/on-success/{}"
+        val expected = "/extraction/on-success/{}/after"
         val target = s"http://$interface:$port/$path"
         Http().singleRequest(HttpRequest(uri = target)).map(_.discardEntityBytes())
 
@@ -114,7 +114,7 @@ class AkkaHttpServerTracingSpec extends WordSpecLike with Matchers with ScalaFut
 
       "take a sampling decision when the routing tree hits a completeOrRecoverWith directive with a failed future" in {
         val path = "extraction/complete-or-recover-with/42/after"
-        val expected = "/extraction/complete-or-recover-with/{}"
+        val expected = "/extraction/complete-or-recover-with/{}/after"
         val target = s"http://$interface:$port/$path"
         Http().singleRequest(HttpRequest(uri = target)).map(_.discardEntityBytes())
 

--- a/kamon-akka-http/src/test/scala/kamon/testkit/TestWebServer.scala
+++ b/kamon-akka-http/src/test/scala/kamon/testkit/TestWebServer.scala
@@ -56,6 +56,7 @@ trait TestWebServer extends TracingDirectives {
           complete("OK")
         } ~
         pathPrefix("extraction") {
+          authenticateBasic("realm", credentials => Option("Okay")) { srt =>
           (post | get) {
             pathPrefix("nested") {
               pathPrefix(IntNumber / "fixed") { num =>
@@ -104,6 +105,7 @@ trait TestWebServer extends TracingDirectives {
             path("segment" / Segment){ segment =>
               complete(HttpResponse(entity = HttpEntity(ContentTypes.`text/plain(UTF-8)`, segment)))
             }
+          }
           }
         } ~
         path(rootOk) {


### PR DESCRIPTION
Since the operation name might be automatically edited more than once while evaluating the routing tree but could also be edited by the users via the `operationName` directive or just manually calling `Kamon.currentSpan.name(...)`, this PR introduces tracking of the last automatic edit, so that the instrumentation will continue to change the operation name but only if the current operation name was set by automatic instrumentation. This ensures that if the user changes the operation name those changes will be kept.