### PR TITLE
Keep strict entities strict

### DIFF
--- a/kamon-akka-http/src/test/scala/kamon/akka/http/ServerFlowWrapperSpec.scala
+++ b/kamon-akka-http/src/test/scala/kamon/akka/http/ServerFlowWrapperSpec.scala
@@ -1,0 +1,34 @@
+package kamon.akka.http
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.{HttpEntity, HttpRequest, HttpResponse, StatusCodes}
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{Flow, Sink, Source}
+import kamon.instrumentation.akka.http.ServerFlowWrapper
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{Matchers, WordSpecLike}
+
+class ServerFlowWrapperSpec extends WordSpecLike with Matchers with ScalaFutures {
+
+  implicit private val system = ActorSystem("http-client-instrumentation-spec")
+  implicit private val executor = system.dispatcher
+  implicit private val materializer = ActorMaterializer()
+
+  private val okReturningFlow = Flow[HttpRequest].map { _ =>
+    HttpResponse(status = StatusCodes.OK, entity = HttpEntity("OK"))
+  }
+
+  "the server flow wrapper" should {
+    "keep strict entities strict" in {
+      val flow = ServerFlowWrapper(okReturningFlow, "localhost", 8080)
+      val request = HttpRequest()
+      val response = Source.single(request)
+        .via(flow)
+        .runWith(Sink.head)
+        .futureValue
+      response.entity should matchPattern {
+        case HttpEntity.Strict(_, _) =>
+      }
+    }
+  }
+}


### PR DESCRIPTION
Resolves #60 
In general it fixes the compatibility with HTTP 1.0, which doesn't support Chunked entities.

The problem is that [`HttpEntity.Strict#transformDataBytes`](https://github.com/akka/akka-http/blob/5c1fcb323fd072cafbd2e21d2ca5cfa5c9f285c2/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala#L343), which is used in `ServerFlowWrapper` returns `HttpEntity.Chunked`.