### PR TITLE
target singleRequestImpl in client instrumentation to intercept Java API calls as well, fixes #65

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ val kamonCore           = "io.kamon" %% "kamon-core"                    % "2.0.0
 val kamonTestKit        = "io.kamon" %% "kamon-testkit"                 % "2.0.0"
 val kamonCommon         = "io.kamon" %% "kamon-instrumentation-common"  % "2.0.0"
 val kamonAkka25         = "io.kamon" %% "kamon-akka"                    % "2.0.0"
-val kanelaAgent         = "io.kamon" %  "kanela-agent"                  % "1.0.0"
+val kanelaAgent         = "io.kamon" %  "kanela-agent"                  % "1.0.1"
 
 val akkaHttpJson        = "de.heikoseeberger" %% "akka-http-json4s"     % "1.27.0"
 val json4sNative        = "org.json4s"        %% "json4s-native"        % "3.6.7"

--- a/kamon-akka-http/src/main/java/kamon/instrumentation/akka/http/HttpExtSingleRequestAdvice.java
+++ b/kamon-akka-http/src/main/java/kamon/instrumentation/akka/http/HttpExtSingleRequestAdvice.java
@@ -1,0 +1,38 @@
+package kamon.instrumentation.akka.http;
+
+import akka.http.scaladsl.model.HttpRequest;
+import akka.http.scaladsl.model.HttpResponse;
+import kamon.Kamon;
+import kamon.context.Storage;
+import kamon.instrumentation.http.HttpClientInstrumentation;
+import kamon.instrumentation.http.HttpMessage;
+import kamon.trace.Span;
+import kanela.agent.libs.net.bytebuddy.asm.Advice;
+import scala.concurrent.Future;
+import static kamon.instrumentation.akka.http.AkkaHttpInstrumentation.toRequestBuilder;
+
+public class HttpExtSingleRequestAdvice {
+
+  @Advice.OnMethodEnter
+  public static void onEnter(@Advice.Argument(value = 0, readOnly = false) HttpRequest request,
+                             @Advice.Local("handler") HttpClientInstrumentation.RequestHandler<HttpRequest> handler,
+                             @Advice.Local("scope")Storage.Scope scope) {
+
+    final HttpMessage.RequestBuilder<HttpRequest> requestBuilder = toRequestBuilder(request);
+
+    handler = AkkaHttpClientInstrumentation.httpClientInstrumentation()
+        .createHandler(requestBuilder, Kamon.currentContext());
+
+    request = handler.request();
+    scope = Kamon.storeContext(Kamon.currentContext().withEntry(Span.Key(), handler.span()));
+  }
+
+  @Advice.OnMethodExit
+  public static void onExit(@Advice.Return Future<HttpResponse> response,
+                            @Advice.Local("handler") HttpClientInstrumentation.RequestHandler<HttpRequest> handler,
+                            @Advice.Local("scope")Storage.Scope scope) {
+
+    AkkaHttpClientInstrumentation.handleResponse(response, handler);
+    scope.close();
+  }
+}

--- a/kamon-akka-http/src/main/scala/kamon/instrumentation/akka/http/AkkaHttpInstrumentation.scala
+++ b/kamon-akka-http/src/main/scala/kamon/instrumentation/akka/http/AkkaHttpInstrumentation.scala
@@ -9,7 +9,7 @@ import scala.collection.immutable
 
 object AkkaHttpInstrumentation {
 
-  Kamon.onReconfigure(_ => HttpExtSingleRequestAdvice.rebuildHttpClientInstrumentation(): Unit)
+  Kamon.onReconfigure(_ => AkkaHttpClientInstrumentation.rebuildHttpClientInstrumentation(): Unit)
 
   def toRequest(httpRequest: HttpRequest): HttpMessage.Request = new RequestReader {
     val request = httpRequest


### PR DESCRIPTION
I had to change form an interceptor in Scala to an Advice on Java because there wasn't any other simpler way of going around it.