### PR TITLE
keep custom operation names, fixes #68

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,9 +16,9 @@
 
 resolvers += Resolver.bintrayRepo("hseeberger", "maven")
 
-val kamonTestKit        = "io.kamon" %% "kamon-testkit"         % "1.0.0"
-val kamonAkka24         = "io.kamon" %% "kamon-akka-2.4"        % "1.0.0"
-val kamonAkka25         = "io.kamon" %% "kamon-akka-2.5"        % "1.0.0"
+val kamonTestKit        = "io.kamon" %% "kamon-testkit"         % "1.1.6"
+val kamonAkka24         = "io.kamon" %% "kamon-akka-2.4"        % "1.1.4"
+val kamonAkka25         = "io.kamon" %% "kamon-akka-2.5"        % "1.1.4"
 val akkaHttpJson        = "de.heikoseeberger" %% "akka-http-json4s" % "1.18.1"
 val json4sNative        = "org.json4s" %% "json4s-native" % "3.5.3"
 

--- a/kamon-akka-http/src/test/resources/application.conf
+++ b/kamon-akka-http/src/test/resources/application.conf
@@ -5,7 +5,7 @@ kamon {
 
   trace.sampler = "always"
 
-  context {
-    codecs.string-keys = [ "custom-string-key" ]
+  context.codecs.string-keys {
+    custom-string-key = "X-custom-string-key"
   }
 }

--- a/kamon-akka-http/src/test/scala/kamon/akka/http/AkkaHttpServerTracingSpec.scala
+++ b/kamon-akka-http/src/test/scala/kamon/akka/http/AkkaHttpServerTracingSpec.scala
@@ -90,7 +90,7 @@ class AkkaHttpServerTracingSpec extends WordSpecLike
     }
 
     //TODO decide what to do with operationName directive, currently whatever it sets gets overriden by instrumentation when route is completed
-/*    "change the Span operation name when using the operationName directive" in {
+    "change the Span operation name when using the operationName directive" in {
       val target = s"http://$interface:$port/$traceOk"
       Http().singleRequest(HttpRequest(uri = target)).map(_.discardEntityBytes())
 
@@ -104,7 +104,7 @@ class AkkaHttpServerTracingSpec extends WordSpecLike
         spanTags("http.url") shouldBe target
         span.tags("http.status_code") shouldBe TagValue.Number(200)
       }
-    }*/
+    }
 
     "mark spans as error when request fails" in {
       val target = s"http://$interface:$port/$dummyPathError"


### PR DESCRIPTION
This is my first attempt at fixing #68. It doesn't back port all of the fixes introduced in master but custom operation names should be kept.

/cc @pnerg